### PR TITLE
Keep Windows startup scripts open on errors

### DIFF
--- a/start-backend.bat
+++ b/start-backend.bat
@@ -1,3 +1,11 @@
 @echo off
 REM Start the Meeplelytics API server in development mode
 npm --workspace server run dev
+set EXITCODE=%errorlevel%
+if not %EXITCODE%==0 (
+    echo.
+    echo Meeplelytics API server exited with error code %EXITCODE%.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b %EXITCODE%
+)

--- a/start-frontend.bat
+++ b/start-frontend.bat
@@ -1,3 +1,11 @@
 @echo off
 REM Start the Meeplelytics web dashboard in development mode
 npm --workspace web run dev
+set EXITCODE=%errorlevel%
+if not %EXITCODE%==0 (
+    echo.
+    echo Meeplelytics web dashboard exited with error code %EXITCODE%.
+    echo Press any key to close this window.
+    pause >nul
+    exit /b %EXITCODE%
+)


### PR DESCRIPTION
## Summary
- preserve the console window when the backend npm dev command exits with an error
- preserve the console window when the frontend npm dev command exits with an error

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e40315ad2c832ca67d7492ed2d6619