### PR TITLE
Keep Windows start scripts open after exit

### DIFF
--- a/start-backend.bat
+++ b/start-backend.bat
@@ -9,3 +9,9 @@ if not %EXITCODE%==0 (
     pause >nul
     exit /b %EXITCODE%
 )
+
+echo.
+echo Meeplelytics API server has stopped.
+echo Press any key to close this window.
+pause >nul
+exit /b 0

--- a/start-frontend.bat
+++ b/start-frontend.bat
@@ -9,3 +9,9 @@ if not %EXITCODE%==0 (
     pause >nul
     exit /b %EXITCODE%
 )
+
+echo.
+echo Meeplelytics web dashboard has stopped.
+echo Press any key to close this window.
+pause >nul
+exit /b 0


### PR DESCRIPTION
## Summary
- add a post-exit pause to the backend and frontend Windows start scripts so their consoles stay open
- show a message indicating whether the process stopped normally or with an error code

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e403cc2368832c870d78bfe857cfc0